### PR TITLE
포인트 충전 api 구현

### DIFF
--- a/src/main/kotlin/io/hhplus/tdd/ApiControllerAdvice.kt
+++ b/src/main/kotlin/io/hhplus/tdd/ApiControllerAdvice.kt
@@ -1,5 +1,6 @@
 package io.hhplus.tdd
 
+import io.hhplus.tdd.point.exception.PointException
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
@@ -13,6 +14,15 @@ data class ErrorResponse(val code: String, val message: String)
 @RestControllerAdvice
 class ApiControllerAdvice : ResponseEntityExceptionHandler() {
     private val logger: Logger = LoggerFactory.getLogger(javaClass)
+
+    @ExceptionHandler(PointException::class)
+    fun handlePointException(e: PointException): ResponseEntity<ErrorResponse> {
+        logger.debug("Error Occurs. type: ${e.javaClass.name} | message: ${e.message}")
+        return ResponseEntity(
+            ErrorResponse("400", e.message()),
+            HttpStatus.BAD_REQUEST,
+        )
+    }
 
     @ExceptionHandler(Exception::class)
     fun handleException(e: Exception): ResponseEntity<ErrorResponse> {

--- a/src/main/kotlin/io/hhplus/tdd/point/PointController.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/PointController.kt
@@ -37,7 +37,7 @@ class PointController {
         @PathVariable id: Long,
         @RequestBody amount: Long,
     ): UserPoint {
-        return UserPoint(0, 0, 0)
+        return UserPoint(id, amount, System.currentTimeMillis())
     }
 
     /**

--- a/src/main/kotlin/io/hhplus/tdd/point/PointController.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/PointController.kt
@@ -1,12 +1,21 @@
 package io.hhplus.tdd.point
 
+import io.hhplus.tdd.point.dto.PointEntityDto
+import io.hhplus.tdd.point.service.PointEntityService
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import org.springframework.web.bind.annotation.*
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/point")
-class PointController {
+class PointController(
+    private val pointEntityService: PointEntityService
+) {
     private val logger: Logger = LoggerFactory.getLogger(javaClass)
 
     /**
@@ -30,14 +39,14 @@ class PointController {
     }
 
     /**
-     * TODO - 특정 유저의 포인트를 충전하는 기능을 작성해주세요.
+     * 특정 유저의 포인트를 충전하는 기능
      */
     @PatchMapping("{id}/charge")
     fun charge(
         @PathVariable id: Long,
         @RequestBody amount: Long,
-    ): UserPoint {
-        return UserPoint(id, amount, System.currentTimeMillis())
+    ): PointEntityDto {
+        return pointEntityService.charge(id, amount)
     }
 
     /**

--- a/src/main/kotlin/io/hhplus/tdd/point/domain/PointEntity.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/domain/PointEntity.kt
@@ -1,0 +1,7 @@
+package io.hhplus.tdd.point.domain
+
+data class PointEntity(
+    val id: Long,
+    val point: Long,
+    val updateMillis: Long
+)

--- a/src/main/kotlin/io/hhplus/tdd/point/domain/PointEntity.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/domain/PointEntity.kt
@@ -1,12 +1,25 @@
 package io.hhplus.tdd.point.domain
 
 import io.hhplus.tdd.point.UserPoint
+import io.hhplus.tdd.point.exception.NegativeAmountException
 
-data class PointEntity(
+class PointEntity(
     val id: Long,
-    val point: Long,
-    val updateMillis: Long
+    point: Long,
+    val updatedMillis: Long
 ) {
+    var point: Long = point
+        private set
+
+    fun addPoint(amount: Long): TransactionEntity {
+        if (amount <= 0)
+            throw NegativeAmountException("amount 는 0보다 커야합니다.")
+
+        point += amount
+
+        return TransactionEntity(0, id, TransactionEntityType.ADD, amount, 0)
+    }
+
     companion object {
         fun from(userPoint: UserPoint): PointEntity {
             return PointEntity(userPoint.id, userPoint.point, userPoint.updateMillis)

--- a/src/main/kotlin/io/hhplus/tdd/point/domain/PointEntity.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/domain/PointEntity.kt
@@ -1,7 +1,15 @@
 package io.hhplus.tdd.point.domain
 
+import io.hhplus.tdd.point.UserPoint
+
 data class PointEntity(
     val id: Long,
     val point: Long,
     val updateMillis: Long
-)
+) {
+    companion object {
+        fun from(userPoint: UserPoint): PointEntity {
+            return PointEntity(userPoint.id, userPoint.point, userPoint.updateMillis)
+        }
+    }
+}

--- a/src/main/kotlin/io/hhplus/tdd/point/domain/TransactionEntity.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/domain/TransactionEntity.kt
@@ -1,13 +1,45 @@
 package io.hhplus.tdd.point.domain
 
+import io.hhplus.tdd.point.PointHistory
+import io.hhplus.tdd.point.TransactionType
+
 data class TransactionEntity(
     val id: Long,
     val userId: Long,
     val type: TransactionEntityType,
     val amount: Long,
-    val timeMillis: Long,
-)
+    val timeMillis: Long
+) {
+
+    companion object {
+        fun from(pointHistory: PointHistory): TransactionEntity {
+            return TransactionEntity(
+                pointHistory.id,
+                pointHistory.userId,
+                TransactionEntityType.from(pointHistory.type),
+                pointHistory.amount,
+                pointHistory.timeMillis
+            )
+        }
+    }
+}
 
 enum class TransactionEntityType {
-    ADD, DEDUCT
+    ADD, DEDUCT;
+
+    fun toTransactionType(): TransactionType {
+        return when (this) {
+            ADD -> TransactionType.CHARGE
+            DEDUCT -> TransactionType.USE
+        }
+    }
+
+    companion object {
+        fun from(transactionType: TransactionType): TransactionEntityType {
+            return when (transactionType) {
+                TransactionType.CHARGE -> ADD
+                TransactionType.USE -> DEDUCT
+            }
+        }
+    }
 }

--- a/src/main/kotlin/io/hhplus/tdd/point/domain/TransactionEntity.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/domain/TransactionEntity.kt
@@ -1,0 +1,13 @@
+package io.hhplus.tdd.point.domain
+
+data class TransactionEntity(
+    val id: Long,
+    val userId: Long,
+    val type: TransactionEntityType,
+    val amount: Long,
+    val timeMillis: Long,
+)
+
+enum class TransactionEntityType {
+    ADD, DEDUCT
+}

--- a/src/main/kotlin/io/hhplus/tdd/point/dto/PointEntityDto.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/dto/PointEntityDto.kt
@@ -1,0 +1,7 @@
+package io.hhplus.tdd.point.dto
+
+data class PointEntityDto(
+    val id: Long,
+    val point: Long,
+    val updateMillis: Long
+)

--- a/src/main/kotlin/io/hhplus/tdd/point/dto/PointEntityDto.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/dto/PointEntityDto.kt
@@ -1,7 +1,15 @@
 package io.hhplus.tdd.point.dto
 
+import io.hhplus.tdd.point.domain.PointEntity
+
 data class PointEntityDto(
     val id: Long,
     val point: Long,
-    val updateMillis: Long
-)
+    val updatedMillis: Long
+) {
+    companion object {
+        fun from(entity: PointEntity): PointEntityDto {
+            return PointEntityDto(entity.id, entity.point, entity.updatedMillis)
+        }
+    }
+}

--- a/src/main/kotlin/io/hhplus/tdd/point/exception/NegativeAmountException.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/exception/NegativeAmountException.kt
@@ -1,4 +1,3 @@
 package io.hhplus.tdd.point.exception
 
-class NegativeAmountException {
-}
+class NegativeAmountException(message: String) : PointException(message)

--- a/src/main/kotlin/io/hhplus/tdd/point/exception/NegativeAmountException.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/exception/NegativeAmountException.kt
@@ -1,0 +1,4 @@
+package io.hhplus.tdd.point.exception
+
+class NegativeAmountException {
+}

--- a/src/main/kotlin/io/hhplus/tdd/point/exception/PointException.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/exception/PointException.kt
@@ -1,0 +1,5 @@
+package io.hhplus.tdd.point.exception
+
+open class PointException(message: String) : Exception(message) {
+    fun message() = message!!
+}

--- a/src/main/kotlin/io/hhplus/tdd/point/infra/PointEntityRepositoryImpl.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/infra/PointEntityRepositoryImpl.kt
@@ -1,0 +1,25 @@
+package io.hhplus.tdd.point.infra
+
+import io.hhplus.tdd.database.UserPointTable
+import io.hhplus.tdd.point.domain.PointEntity
+import io.hhplus.tdd.point.repository.PointEntityRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+class PointEntityRepositoryImpl(
+    private val userPointTable: UserPointTable
+) : PointEntityRepository {
+    override fun findOrCreateByUserId(userId: Long): PointEntity {
+        return PointEntity.from(userPointTable.selectById(userId))
+    }
+
+    override fun insertOrUpdate(pointEntity: PointEntity): PointEntity {
+        return PointEntity.from(
+            userPointTable.insertOrUpdate(pointEntity.id, pointEntity.point)
+        )
+    }
+
+    override fun deleteAll() {
+        // nothing to do
+    }
+}

--- a/src/main/kotlin/io/hhplus/tdd/point/repository/PointEntityRepository.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/repository/PointEntityRepository.kt
@@ -1,0 +1,11 @@
+package io.hhplus.tdd.point.repository
+
+import io.hhplus.tdd.point.domain.PointEntity
+
+interface PointEntityRepository {
+    fun findOrCreateByUserId(userId: Long): PointEntity
+
+    fun insertOrUpdate(pointEntity: PointEntity): PointEntity
+
+    fun deleteAll()
+}

--- a/src/main/kotlin/io/hhplus/tdd/point/repository/TransactionEntityRepository.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/repository/TransactionEntityRepository.kt
@@ -1,9 +1,13 @@
 package io.hhplus.tdd.point.repository
 
+import io.hhplus.tdd.point.domain.PointEntity
 import io.hhplus.tdd.point.domain.TransactionEntity
+import io.hhplus.tdd.point.domain.TransactionEntityType
 
 interface TransactionEntityRepository {
     fun findAllByUserId(userId: Long): List<TransactionEntity>
+
+    fun insert(pointEntity: PointEntity, amount: Long, type: TransactionEntityType): TransactionEntity
 
     fun deleteAll()
 }

--- a/src/main/kotlin/io/hhplus/tdd/point/repository/TransactionEntityRepository.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/repository/TransactionEntityRepository.kt
@@ -1,0 +1,9 @@
+package io.hhplus.tdd.point.repository
+
+import io.hhplus.tdd.point.domain.TransactionEntity
+
+interface TransactionEntityRepository {
+    fun findAllByUserId(userId: Long): List<TransactionEntity>
+
+    fun deleteAll()
+}

--- a/src/main/kotlin/io/hhplus/tdd/point/service/PointEntityService.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/service/PointEntityService.kt
@@ -1,0 +1,11 @@
+package io.hhplus.tdd.point.service
+
+import io.hhplus.tdd.point.dto.PointEntityDto
+import org.springframework.stereotype.Service
+
+@Service
+class PointEntityService {
+    fun charge(id: Long, amount: Long): PointEntityDto {
+        return PointEntityDto()
+    }
+}

--- a/src/main/kotlin/io/hhplus/tdd/point/service/PointEntityService.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/service/PointEntityService.kt
@@ -6,6 +6,6 @@ import org.springframework.stereotype.Service
 @Service
 class PointEntityService {
     fun charge(id: Long, amount: Long): PointEntityDto {
-        return PointEntityDto()
+        return PointEntityDto(0, 0, System.currentTimeMillis())
     }
 }

--- a/src/main/kotlin/io/hhplus/tdd/point/service/PointEntityService.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/service/PointEntityService.kt
@@ -1,11 +1,29 @@
 package io.hhplus.tdd.point.service
 
 import io.hhplus.tdd.point.dto.PointEntityDto
+import io.hhplus.tdd.point.repository.PointEntityRepository
+import io.hhplus.tdd.point.repository.TransactionEntityRepository
 import org.springframework.stereotype.Service
 
 @Service
-class PointEntityService {
+class PointEntityService(
+    private val pointEntityRepository: PointEntityRepository,
+    private val transactionEntityRepository: TransactionEntityRepository
+) {
     fun charge(id: Long, amount: Long): PointEntityDto {
-        return PointEntityDto(0, 0, System.currentTimeMillis())
+        val pointEntity = pointEntityRepository.findOrCreateByUserId(id)
+
+        // 포인트 충전 비지니스 로직 실행
+        val transaction = pointEntity.addPoint(amount)
+
+        // 변경된 UserEntity 저장
+        val updatedOne = pointEntityRepository.insertOrUpdate(pointEntity)
+
+        // 변경사항인 transaction 저장
+        transactionEntityRepository.insert(
+            updatedOne, transaction.amount, transaction.type
+        )
+
+        return PointEntityDto.from(updatedOne)
     }
 }

--- a/src/test/kotlin/io/hhplus/tdd/point/PointControllerTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/PointControllerTest.kt
@@ -56,7 +56,7 @@ class PointControllerTest @Autowired constructor(
         resultActions.andExpect(status().isOk)
             .andExpect(jsonPath("$.id").value(userId))
             .andExpect(jsonPath("$.point").value(point + amount))
-            .andExpect(jsonPath("$.updateMillis").value(greaterThan(pointEntity.updatedMillis)))
+            .andExpect(jsonPath("$.updatedMillis").value(greaterThan(pointEntity.updatedMillis)))
 
         verify(pointEntityRepository).findOrCreateByUserId(userId)
     }
@@ -82,7 +82,7 @@ class PointControllerTest @Autowired constructor(
         resultActions.andExpect(status().isOk)
             .andExpect(jsonPath("$.id").value(userId))
             .andExpect(jsonPath("$.point").value(amount))
-            .andExpect(jsonPath("$.updateMillis").isNumber)
+            .andExpect(jsonPath("$.updatedMillis").isNumber)
     }
 
     /**

--- a/src/test/kotlin/io/hhplus/tdd/point/PointControllerTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/PointControllerTest.kt
@@ -56,7 +56,7 @@ class PointControllerTest @Autowired constructor(
         resultActions.andExpect(status().isOk)
             .andExpect(jsonPath("$.id").value(userId))
             .andExpect(jsonPath("$.point").value(point + amount))
-            .andExpect(jsonPath("$.updateMillis").value(greaterThan(pointEntity.updateMillis)))
+            .andExpect(jsonPath("$.updateMillis").value(greaterThan(pointEntity.updatedMillis)))
 
         verify(pointEntityRepository).findOrCreateByUserId(userId)
     }

--- a/src/test/kotlin/io/hhplus/tdd/point/PointControllerTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/PointControllerTest.kt
@@ -6,6 +6,7 @@ import org.hamcrest.Matchers.greaterThan
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito.given
+import org.mockito.BDDMockito.reset
 import org.mockito.BDDMockito.verify
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
@@ -25,6 +26,8 @@ class PointControllerTest @Autowired constructor(
 ) {
     @AfterEach
     fun afterEach() {
+        reset(pointEntityRepository)
+
         pointEntityRepository.deleteAll()
     }
 

--- a/src/test/kotlin/io/hhplus/tdd/point/PointControllerTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/PointControllerTest.kt
@@ -1,0 +1,107 @@
+package io.hhplus.tdd.point
+
+import io.hhplus.tdd.point.domain.PointEntity
+import io.hhplus.tdd.point.repository.PointEntityRepository
+import org.hamcrest.Matchers.greaterThan
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.mockito.BDDMockito.given
+import org.mockito.BDDMockito.verify
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.SpyBean
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class PointControllerTest @Autowired constructor(
+    @SpyBean private val pointEntityRepository: PointEntityRepository,
+    private val mockMvc: MockMvc
+) {
+    @AfterEach
+    fun afterEach() {
+        pointEntityRepository.deleteAll()
+    }
+
+    /**
+     * 사용자와 양수인 포인트 충전을 요청을 받으면,
+     * 포인트 충전 후 사용자의 id, 기존 포인트 + 요청 받은 포인트, 충전 시간을 보내주어야 한다.
+     */
+    @Test
+    fun `should charge amount and return 200 ok with charged points`() {
+        // given
+        val userId = 1L
+        val point = 1000L
+        val amount = 100L
+
+        val pointEntity = PointEntity(userId, point, System.currentTimeMillis() - 10)
+        given(pointEntityRepository.findOrCreateByUserId(userId)).willReturn(pointEntity)
+
+        // when
+        val resultActions = mockMvc.perform(
+            patch("/point/$userId/charge")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(amount.toString())
+        )
+
+        // then
+        resultActions.andExpect(status().isOk)
+            .andExpect(jsonPath("$.id").value(userId))
+            .andExpect(jsonPath("$.point").value(point + amount))
+            .andExpect(jsonPath("$.updateMillis").value(greaterThan(pointEntity.updateMillis)))
+
+        verify(pointEntityRepository).findOrCreateByUserId(userId)
+    }
+
+    /**
+     * 존재 하지 않는 사용자에 대해서 충전을 요청받았다면,
+     * 해당 id 로 새로운 PointEntity 를 만들고, 요청 받은 만큼 충전해서 보내주어야 한다.
+     */
+    @Test
+    fun `should create new PointEntity and return 200 ok with charged point`() {
+        // given
+        val userId = 2L
+        val amount = 400L
+
+        // when
+        val resultActions = mockMvc.perform(
+            patch("/point/$userId/charge")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(amount.toString())
+        )
+
+        // then
+        resultActions.andExpect(status().isOk)
+            .andExpect(jsonPath("$.id").value(userId))
+            .andExpect(jsonPath("$.point").value(amount))
+            .andExpect(jsonPath("$.updateMillis").isNumber)
+    }
+
+    /**
+     * 음수인 포인트로 충전을 요청 받았다면,
+     * 충전할 수 없다는 error response 를 status code 400 과 함께 보내주어야 한다.
+     */
+    @Test
+    fun `should return 400 bad request for negative amount`() {
+        // given
+        val userId = 1
+        val amount = -100L
+
+        // when
+        val resultActions = mockMvc.perform(
+            patch("/point/$userId/charge")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(amount.toString())
+        )
+
+        // then
+        resultActions.andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.code").value(400))
+            .andExpect(jsonPath("$.message").value("amount 는 0보다 커야합니다."))
+    }
+}

--- a/src/test/kotlin/io/hhplus/tdd/point/domain/PointEntityTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/domain/PointEntityTest.kt
@@ -1,0 +1,56 @@
+package io.hhplus.tdd.point.domain
+
+import io.hhplus.tdd.point.exception.NegativeAmountException
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+
+class PointEntityTest {
+
+    /**
+     * 자연수인 포인트를 추가하면, 보유량을 그 만큼 증가시켜야 한다.
+     */
+    @Test
+    fun `should increase points`() {
+        // given
+        val userEntity = PointEntity(11L, 210L, System.currentTimeMillis())
+        val amount = 210L
+
+        // when
+        val transaction = userEntity.addPoint(amount)
+
+        // then
+        Assertions.assertThat(userEntity.point).isEqualTo(420L)
+        Assertions.assertThat(transaction.amount).isEqualTo(amount)
+        Assertions.assertThat(transaction.type).isEqualTo(TransactionEntityType.ADD)
+    }
+
+    /**
+     * 음수 포인트를 추가하려고 하면, NegativeAmountException 을 던져야 한다.
+     */
+    @Test
+    fun `should throw NegativeAmountException for negative amount`() {
+        // given
+        val userEntity = PointEntity(1L, 100L, System.currentTimeMillis())
+        val negativeAmount = -210L
+
+        // when & then
+        Assertions.assertThatThrownBy { userEntity.addPoint(negativeAmount) }
+            .isInstanceOf(NegativeAmountException::class.java)
+            .hasMessageContaining("amount 는 0보다 커야합니다.")
+    }
+
+    /**
+     * 0 포인트를 추가하려고 하면, NegativeAmountException 을 던져야 한다.
+     */
+    @Test
+    fun `should throw NegativeAmountException for zero amount`() {
+        // given
+        val userEntity = PointEntity(1L, 100L, System.currentTimeMillis())
+        val zeroAmount = 0L
+
+        // when & then
+        Assertions.assertThatThrownBy { userEntity.addPoint(zeroAmount) }
+            .isInstanceOf(NegativeAmountException::class.java)
+            .hasMessageContaining("amount 는 0보다 커야합니다.")
+    }
+}

--- a/src/test/kotlin/io/hhplus/tdd/point/mock/StubPointEntityRepository.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/mock/StubPointEntityRepository.kt
@@ -1,0 +1,26 @@
+package io.hhplus.tdd.point.mock
+
+import io.hhplus.tdd.point.domain.PointEntity
+import io.hhplus.tdd.point.repository.PointEntityRepository
+import org.springframework.context.annotation.Primary
+import org.springframework.stereotype.Repository
+
+@Primary
+@Repository
+class StubPointEntityRepository : PointEntityRepository {
+    private val table = HashMap<Long, PointEntity>()
+    override fun findOrCreateByUserId(userId: Long): PointEntity {
+        return table[userId] ?: PointEntity(userId, 0, System.currentTimeMillis())
+    }
+
+    override fun insertOrUpdate(pointEntity: PointEntity): PointEntity {
+        val userId = pointEntity.id
+        val newPointEntity = PointEntity(userId, pointEntity.point, System.currentTimeMillis())
+        table[userId] = newPointEntity
+        return newPointEntity
+    }
+
+    override fun deleteAll() {
+        table.clear()
+    }
+}

--- a/src/test/kotlin/io/hhplus/tdd/point/mock/StubTransactionEntityRepository.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/mock/StubTransactionEntityRepository.kt
@@ -1,0 +1,20 @@
+package io.hhplus.tdd.point.mock
+
+import io.hhplus.tdd.point.domain.TransactionEntity
+import io.hhplus.tdd.point.repository.TransactionEntityRepository
+import org.springframework.context.annotation.Primary
+import org.springframework.stereotype.Repository
+
+@Primary
+@Repository
+class StubTransactionEntityRepository : TransactionEntityRepository {
+    private val table = mutableListOf<TransactionEntity>()
+
+    override fun findAllByUserId(userId: Long): List<TransactionEntity> {
+        return table.filter { it.userId == userId }
+    }
+
+    override fun deleteAll() {
+        table.clear()
+    }
+}

--- a/src/test/kotlin/io/hhplus/tdd/point/service/PointEntityServiceTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/service/PointEntityServiceTest.kt
@@ -1,0 +1,75 @@
+package io.hhplus.tdd.point.service
+
+import io.hhplus.tdd.point.domain.PointEntity
+import io.hhplus.tdd.point.domain.TransactionEntityType
+import io.hhplus.tdd.point.exception.NegativeAmountException
+import io.hhplus.tdd.point.repository.PointEntityRepository
+import io.hhplus.tdd.point.repository.TransactionEntityRepository
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.mockito.BDDMockito.given
+import org.mockito.BDDMockito.reset
+import org.mockito.BDDMockito.verify
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.SpyBean
+
+@SpringBootTest
+class PointEntityServiceTest @Autowired constructor(
+    @SpyBean private val pointEntityRepository: PointEntityRepository,
+    @SpyBean private val transactionEntityRepository: TransactionEntityRepository,
+    private val pointEntityService: PointEntityService
+) {
+    @AfterEach
+    fun afterEach() {
+        reset(pointEntityRepository)
+        reset(transactionEntityRepository)
+
+        pointEntityRepository.deleteAll()
+        transactionEntityRepository.deleteAll()
+    }
+
+    /**
+     * 양수 amount 로 charge 를 시도하면,
+     * ADD type 의 TransactionEntity 를 추가하고, 또한 충전된 정보로 PointEntityDto 를 반환해야한다.
+     */
+    @Test
+    fun `should return UserEntityDto that has the added points and insert TransactionEntity`() {
+        // given: PointEntity 1 개가 있고, transaction 은 없는 상황
+        val pointEntity = PointEntity(1L, 1000L, System.currentTimeMillis() - 10)
+        given(pointEntityRepository.findOrCreateByUserId(pointEntity.id)).willReturn(pointEntity)
+
+        val transactionCount = transactionEntityRepository.findAllByUserId(pointEntity.id).count()
+        val amount = 100L
+
+        // when
+        val dto = pointEntityService.charge(pointEntity.id, amount)
+
+        // then: 충전이 반영된 PointEntityDto 가 오고, transaction 은 원래보다 1개 늘어났는지 확인
+        Assertions.assertThat(dto.id).isEqualTo(pointEntity.id)
+        Assertions.assertThat(dto.point).isEqualTo(pointEntity.point + amount)
+
+        val history = transactionEntityRepository.findAllByUserId(pointEntity.id)
+        Assertions.assertThat(history.count()).isEqualTo(transactionCount + 1)
+        Assertions.assertThat(history.last().amount).isEqualTo(amount)
+        Assertions.assertThat(history.last().type).isEqualTo(TransactionEntityType.ADD)
+
+        verify(pointEntityRepository).findOrCreateByUserId(pointEntity.id)
+    }
+
+    /**
+     * 음수인 amount 로 charge 를 시도하면, NegativeAmountException 을 발생시켜야한다.
+     */
+    @Test
+    fun `should throw NegativeAmountException when trying to charge negative amount`() {
+        // given
+        val userId = 1L
+        val negativeAmount = -1000L
+
+        // when & then
+        Assertions.assertThatThrownBy { pointEntityService.charge(userId, negativeAmount) }
+            .isInstanceOf(NegativeAmountException::class.java)
+            .hasMessageContaining("amount 는 0보다 커야합니다.")
+    }
+}


### PR DESCRIPTION
## 변경사항

- PATCH  /point/{id}/charge 구현
- 응용 로직 작성
    - PointEntityService 에서 PointEntityRepository 로 부터 PointEntity 가져와, addPoint 로 비지니스 로직을 실행합니다.
    - PointEntityService 에서 PointEntityRepository 와 TransactionEntityRepository 를 통해 변경사항을 업데이트합니다.
- 도메인 로직 작성
    - PointEntity 를 통해 포인트 추가할 수 있도록 작성했습니다.
    - 포인트 증가
        - UserEntity 의 addPoint 에서 포인트 증가를 합니다.
        - 0 및 음수로 포인트를 증가시키려 하면, `NegativeAmountException` 을 발생시킵니다.
- 인프라 로직 작성
    - UserEntityRepositoryImpl 에서 UserPointTable 참조해서 작업을 하고, 매개변수와 반환은 PointEntity 로 하도록 하였습니다.

- EtoE Test 작성
    - PointControllerTest
- Integration Test 작성
    - PointEntityServiceTest
- Unit Test 작성
    - PointEntityTest

- 리뷰 포인트
    - TDD 에 맞게 구현을 해보려 했으며, 그 과정을 commit 으로 잘게 하는 것으로 기록했습니다. 이런 과정이 맞는지 코멘트 부탁드립니다.
    - 도메인 모델, Dto 등을 따로 정의하여 분리를 하고자 하였는데 이 부분 리뷰 부탁드립니다.
    - 요구사항을 만족하려면 필요한 테스트 케이스들을 모두 작성했다고 생각하는 이 부분 리뷰 부탁드립니다.