### PR TITLE
포인트 조회 api 구현

### DIFF
--- a/src/main/kotlin/io/hhplus/tdd/point/PointController.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/PointController.kt
@@ -19,13 +19,13 @@ class PointController(
     private val logger: Logger = LoggerFactory.getLogger(javaClass)
 
     /**
-     * TODO - 특정 유저의 포인트를 조회하는 기능을 작성해주세요.
+     * 특정 유저의 포인트를 조회하는 기능
      */
     @GetMapping("{id}")
     fun point(
         @PathVariable id: Long,
-    ): UserPoint {
-        return UserPoint(0, 0, 0)
+    ): PointEntityDto {
+        return pointEntityService.findOrCreateOneById(id)
     }
 
     /**

--- a/src/main/kotlin/io/hhplus/tdd/point/service/PointEntityService.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/service/PointEntityService.kt
@@ -26,4 +26,8 @@ class PointEntityService(
 
         return PointEntityDto.from(updatedOne)
     }
+
+    fun findOrCreateOneById(id: Long): PointEntityDto {
+        return PointEntityDto.from(pointEntityRepository.findOrCreateByUserId(id))
+    }
 }

--- a/src/test/kotlin/io/hhplus/tdd/point/service/PointEntityServiceTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/service/PointEntityServiceTest.kt
@@ -76,4 +76,41 @@ class PointEntityServiceTest @Autowired constructor(
             .isInstanceOf(NegativeAmountException::class.java)
             .hasMessageContaining("amount 는 0보다 커야합니다.")
     }
+
+    /**
+     * 저장되어있는 UserPoint 의 id 로 조회를 시도하면,
+     * 해당 UserPoint 의 정보를 PointEntityDto 로 반환해야한다.
+     */
+    @Test
+    fun `should return UserEntityDto about saved UserPoint`() {
+        // given
+
+        val pointEntity = PointEntity(2L, 900L, System.currentTimeMillis() - 10)
+        given(pointEntityRepository.findOrCreateByUserId(pointEntity.id)).willReturn(pointEntity)
+
+        // when
+        val userPointDto = pointEntityService.findOrCreateOneById(pointEntity.id)
+
+        // then
+        Assertions.assertThat(userPointDto.id).isEqualTo(pointEntity.id)
+        Assertions.assertThat(userPointDto.point).isEqualTo(pointEntity.point)
+        Assertions.assertThat(userPointDto.updatedMillis).isEqualTo(pointEntity.updatedMillis)
+    }
+
+    /**
+     * 새로운 id 로 findOrCreateOneById 시도하면,
+     * 새로운 UserPoint 에 대한 PointEntityDto 를 반환해야한다.
+     */
+    @Test
+    fun `should return new UserEntityDto about new userId`() {
+        // given
+        val newId = 21L
+
+        // when
+        val newUserPointDto = pointEntityService.findOrCreateOneById(newId)
+
+        // then
+        Assertions.assertThat(newUserPointDto.id).isEqualTo(newId)
+        Assertions.assertThat(newUserPointDto.point).isEqualTo(0)
+    }
 }


### PR DESCRIPTION
- GET /point/{id} 구현
- 표현 로직 작성
    - PointController 에서 PointEntityService::findOrCreateOneById 을 호출하도록 하였습니다.
    - 반환 타입을 PointEntityDto 로 변경하였습니다.
- 응용 로직 작성
    - PointEntityService 에서 PointEntityRepository::findOrCreateById 를 호출하여 가져온 PointEntity 를 PointEntityDto 로 변환하여 반환하도록 하였습니다.
- EtoE Test 작성
    - PointControllerTest::`should return 200 ok with PointEntityDto when getting point`
    - PointControllerTest:: `should return 200 ok with new PointEntityDto when getting point with new userId`
Integration Test 작성
    - PointEntityServiceTest::`should return UserEntityDto about saved UserPoint`
    - PointEntityServiceTest::`should return new UserEntityDto about new userId`

- 리뷰 포인트
    - PointController::point -> PointEntityService::findOrCreateOneById -> PointEntityRepository::findOrCreateById 로 위임을 계속하는데 이러한 구조에 대해 리뷰 부탁드립니다.