### PR TITLE
포인트 내역 조회 api 구현

### DIFF
--- a/src/main/kotlin/io/hhplus/tdd/point/PointController.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/PointController.kt
@@ -1,6 +1,7 @@
 package io.hhplus.tdd.point
 
 import io.hhplus.tdd.point.dto.PointEntityDto
+import io.hhplus.tdd.point.dto.TransactionEntityDto
 import io.hhplus.tdd.point.service.PointEntityService
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -29,13 +30,13 @@ class PointController(
     }
 
     /**
-     * TODO - 특정 유저의 포인트 충전/이용 내역을 조회하는 기능을 작성해주세요.
+     * 특정 유저의 포인트 충전/이용 내역을 조회하는 기능
      */
     @GetMapping("{id}/histories")
     fun history(
         @PathVariable id: Long,
-    ): List<PointHistory> {
-        return emptyList()
+    ): List<TransactionEntityDto> {
+        return pointEntityService.findTransactionsByUserId(id)
     }
 
     /**

--- a/src/main/kotlin/io/hhplus/tdd/point/dto/TransactionEntityDto.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/dto/TransactionEntityDto.kt
@@ -1,0 +1,24 @@
+package io.hhplus.tdd.point.dto
+
+import io.hhplus.tdd.point.TransactionType
+import io.hhplus.tdd.point.domain.TransactionEntity
+
+data class TransactionEntityDto(
+    val id: Long,
+    val userId: Long,
+    val type: TransactionType,
+    val amount: Long,
+    val timeMillis: Long
+) {
+    companion object {
+        fun from(transaction: TransactionEntity): TransactionEntityDto {
+            return TransactionEntityDto(
+                transaction.id,
+                transaction.userId,
+                transaction.type.toTransactionType(),
+                transaction.amount,
+                transaction.timeMillis
+            )
+        }
+    }
+}

--- a/src/main/kotlin/io/hhplus/tdd/point/service/PointEntityService.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/service/PointEntityService.kt
@@ -1,6 +1,7 @@
 package io.hhplus.tdd.point.service
 
 import io.hhplus.tdd.point.dto.PointEntityDto
+import io.hhplus.tdd.point.dto.TransactionEntityDto
 import io.hhplus.tdd.point.repository.PointEntityRepository
 import io.hhplus.tdd.point.repository.TransactionEntityRepository
 import org.springframework.stereotype.Service
@@ -29,5 +30,9 @@ class PointEntityService(
 
     fun findOrCreateOneById(id: Long): PointEntityDto {
         return PointEntityDto.from(pointEntityRepository.findOrCreateByUserId(id))
+    }
+
+    fun findTransactionsByUserId(userId: Long): List<TransactionEntityDto> {
+        return transactionEntityRepository.findAllByUserId(userId).map { TransactionEntityDto.from(it) }
     }
 }

--- a/src/test/kotlin/io/hhplus/tdd/point/PointControllerTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/PointControllerTest.kt
@@ -195,7 +195,6 @@ class PointControllerTest @Autowired constructor(
 
         verify(pointEntityRepository).findOrCreateByUserId(userId)
         verify(transactionEntityRepository).findAllByUserId(userId)
-
     }
 
     /**

--- a/src/test/kotlin/io/hhplus/tdd/point/PointControllerTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/PointControllerTest.kt
@@ -168,13 +168,11 @@ class PointControllerTest @Autowired constructor(
      */
     @Test
     fun `should return 200 ok with transactions associated with id`() {
-        // given: PointEntity 와 그 PointEntity 에 연결된 TransactionEntity 1개가 주어진 상황
+        // given: TransactionEntity 1개가 주어진 상황
         val userId = 1L
-        val pointEntity = PointEntity(userId, 100L, System.currentTimeMillis() - 10)
-        given(pointEntityRepository.findOrCreateByUserId(userId)).willReturn(pointEntity)
-
-        val transactionEntity =
-            TransactionEntity(1L, userId, TransactionEntityType.ADD, 100L, pointEntity.updatedMillis)
+        val transactionEntity = TransactionEntity(
+            1L, userId, TransactionEntityType.ADD, 100L, System.currentTimeMillis() - 5
+        )
         given(transactionEntityRepository.findAllByUserId(userId)).willReturn(listOf(transactionEntity))
 
         // when
@@ -189,11 +187,10 @@ class PointControllerTest @Autowired constructor(
             .andExpect(jsonPath("$.length()").value(1))
             .andExpect(jsonPath("$[0].id").value(transactionEntity.id))
             .andExpect(jsonPath("$[0].userId").value(transactionEntity.userId))
-            .andExpect(jsonPath("$[0].type").value(transactionEntity.type))
+            .andExpect(jsonPath("$[0].type").value(transactionEntity.type.toTransactionType().toString()))
             .andExpect(jsonPath("$[0].amount").value(transactionEntity.amount))
             .andExpect(jsonPath("$[0].timeMillis").value(transactionEntity.timeMillis))
-
-        verify(pointEntityRepository).findOrCreateByUserId(userId)
+        
         verify(transactionEntityRepository).findAllByUserId(userId)
     }
 
@@ -204,8 +201,6 @@ class PointControllerTest @Autowired constructor(
     fun `should return 200 ok with empty list when user has no transaction`() {
         // given
         val userId = 1L
-        val pointEntity = PointEntity(userId, 0L, System.currentTimeMillis() - 10)
-        given(pointEntityRepository.findOrCreateByUserId(userId)).willReturn(pointEntity)
 
         // when
         val resultActions = mockMvc.perform(
@@ -216,8 +211,6 @@ class PointControllerTest @Autowired constructor(
         resultActions.andExpect(status().isOk)
             .andExpect(jsonPath("$").isArray)
             .andExpect(jsonPath("$").isEmpty)
-
-        verify(pointEntityRepository).findOrCreateByUserId(userId)
     }
 
     /**

--- a/src/test/kotlin/io/hhplus/tdd/point/service/PointEntityServiceTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/service/PointEntityServiceTest.kt
@@ -84,7 +84,6 @@ class PointEntityServiceTest @Autowired constructor(
     @Test
     fun `should return UserEntityDto about saved UserPoint`() {
         // given
-
         val pointEntity = PointEntity(2L, 900L, System.currentTimeMillis() - 10)
         given(pointEntityRepository.findOrCreateByUserId(pointEntity.id)).willReturn(pointEntity)
 


### PR DESCRIPTION
- GET /point/{id}/histories 구현
- 표현 로직 작성
    - PointController 에서 PointEntityService::findTransactionsByUserId 을 호출하도록 하였습니다.
    - 반환 타입을 List<TransactionEntityDto> 로 변경하였습니다.
- 응용 로직 작성
    - PointEntityService 에서 TransactionEntityRepository::findAllByUserId 를 호출하여 가져온 TransactionEntity 리스트를 List<TransactionEntityDto> 로 변환하여 반환하도록 하였습니다.
- EtoE Test 작성
    - PointControllerTest::`should return 200 ok with transactions associated with id`
    - PointControllerTest::`should return 200 ok with empty list when user has no transaction`
    - PointControllerTest::`should return 200 ok with empty list about unknown id`
Integration Test 작성
    - PointEntityServiceTest::`should return transactions associated with userId`
    - PointEntityServiceTest::`should return empty list when user has no transaction`
    - PointEntityServiceTest::`should return empty list about unknown userId`

- 리뷰 포인트
    - 빈 배열이 올 수 있는 경우까지 test case 를 작성했는데, 이렇게 하는 것이 맞을까요?