### PR TITLE
포인트 사용 api 구현

### DIFF
--- a/src/main/kotlin/io/hhplus/tdd/point/PointController.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/PointController.kt
@@ -51,13 +51,13 @@ class PointController(
     }
 
     /**
-     * TODO - 특정 유저의 포인트를 사용하는 기능을 작성해주세요.
+     * 특정 유저의 포인트를 사용하는 기능
      */
     @PatchMapping("{id}/use")
     fun use(
         @PathVariable id: Long,
         @RequestBody amount: Long,
-    ): UserPoint {
-        return UserPoint(0, 0, 0)
+    ): PointEntityDto {
+        return pointEntityService.use(id, amount)
     }
 }

--- a/src/main/kotlin/io/hhplus/tdd/point/domain/PointEntity.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/domain/PointEntity.kt
@@ -1,6 +1,7 @@
 package io.hhplus.tdd.point.domain
 
 import io.hhplus.tdd.point.UserPoint
+import io.hhplus.tdd.point.exception.ExceedPointException
 import io.hhplus.tdd.point.exception.NegativeAmountException
 
 class PointEntity(
@@ -12,13 +13,33 @@ class PointEntity(
         private set
 
     fun addPoint(amount: Long): TransactionEntity {
-        if (amount <= 0)
-            throw NegativeAmountException("amount 는 0보다 커야합니다.")
+        verifyAmountIsNaturalNumber(amount)
 
         point += amount
 
         return TransactionEntity(0, id, TransactionEntityType.ADD, amount, 0)
     }
+
+    fun deductPoint(amount: Long): TransactionEntity {
+        verifyAmountIsNaturalNumber(amount)
+
+        verifyAmountIsEqualOrLessThanPoint(amount)
+
+        point -= amount
+
+        return TransactionEntity(0, id, TransactionEntityType.DEDUCT, amount, 0)
+    }
+
+    private fun verifyAmountIsNaturalNumber(amount: Long) {
+        if (amount <= 0)
+            throw NegativeAmountException("amount 는 0보다 커야합니다.")
+    }
+
+    private fun verifyAmountIsEqualOrLessThanPoint(amount: Long) {
+        if (amount > point)
+            throw ExceedPointException("amount 는 포인트보다 클 수 없습니다.")
+    }
+
 
     companion object {
         fun from(userPoint: UserPoint): PointEntity {

--- a/src/main/kotlin/io/hhplus/tdd/point/exception/ExceedPointException.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/exception/ExceedPointException.kt
@@ -1,0 +1,3 @@
+package io.hhplus.tdd.point.exception
+
+class ExceedPointException(message: String) : PointException(message)

--- a/src/main/kotlin/io/hhplus/tdd/point/service/PointEntityService.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/service/PointEntityService.kt
@@ -11,8 +11,8 @@ class PointEntityService(
     private val pointEntityRepository: PointEntityRepository,
     private val transactionEntityRepository: TransactionEntityRepository
 ) {
-    fun charge(id: Long, amount: Long): PointEntityDto {
-        val pointEntity = pointEntityRepository.findOrCreateByUserId(id)
+    fun charge(userId: Long, amount: Long): PointEntityDto {
+        val pointEntity = pointEntityRepository.findOrCreateByUserId(userId)
 
         // 포인트 충전 비지니스 로직 실행
         val transaction = pointEntity.addPoint(amount)
@@ -34,5 +34,22 @@ class PointEntityService(
 
     fun findTransactionsByUserId(userId: Long): List<TransactionEntityDto> {
         return transactionEntityRepository.findAllByUserId(userId).map { TransactionEntityDto.from(it) }
+    }
+
+    fun use(userId: Long, amount: Long): PointEntityDto {
+        val pointEntity = pointEntityRepository.findOrCreateByUserId(userId)
+
+        // 포인트 사용 비지니스 로직 실행
+        val transaction = pointEntity.deductPoint(amount)
+
+        // 변경된 UserEntity 저장
+        val updatedOne = pointEntityRepository.insertOrUpdate(pointEntity)
+
+        // 변경사항인 transaction 저장
+        transactionEntityRepository.insert(
+            updatedOne, transaction.amount, transaction.type
+        )
+
+        return PointEntityDto.from(updatedOne)
     }
 }

--- a/src/test/kotlin/io/hhplus/tdd/point/domain/PointEntityTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/domain/PointEntityTest.kt
@@ -1,5 +1,6 @@
 package io.hhplus.tdd.point.domain
 
+import io.hhplus.tdd.point.exception.ExceedPointException
 import io.hhplus.tdd.point.exception.NegativeAmountException
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
@@ -50,6 +51,71 @@ class PointEntityTest {
 
         // when & then
         Assertions.assertThatThrownBy { userEntity.addPoint(zeroAmount) }
+            .isInstanceOf(NegativeAmountException::class.java)
+            .hasMessageContaining("amount 는 0보다 커야합니다.")
+    }
+
+    /**
+     * 자연수인 포인트를 빼면, 보유량을 그 만큼 감소시키고 그 transaction 을 반환해야한다.
+     */
+    @Test
+    fun `should decrease points and save the transaction`() {
+        // given
+        val userId = 11L
+        val point = 210L
+        val amount = 210L
+        val pointEntity = PointEntity(userId, point, System.currentTimeMillis() - 10)
+
+        // when
+        val transaction = pointEntity.deductPoint(amount)
+
+        // then
+        Assertions.assertThat(pointEntity.point).isEqualTo(0)
+        Assertions.assertThat(transaction.amount).isEqualTo(amount)
+        Assertions.assertThat(transaction.type).isEqualTo(TransactionEntityType.DEDUCT)
+    }
+
+    /**
+     * 보유량보다 큰 포인트로 빼려고 하면, ExceedPointException 을 던져야 한다.
+     */
+    @Test
+    fun `should throw ExceedPointException when trying with more amount than available`() {
+        // given
+        val pointEntity = PointEntity(1L, 100L, System.currentTimeMillis() - 1)
+        val amount = 210L
+
+        // when & then
+        Assertions.assertThatThrownBy { pointEntity.deductPoint(amount) }
+            .isInstanceOf(ExceedPointException::class.java)
+            .hasMessageContaining("amount 는 포인트보다 클 수 없습니다.")
+    }
+
+    /**
+     * 음수 포인트로 빼려고 하면, NegativeAmountException 을 던져야 한다.
+     */
+    @Test
+    fun `should throw NegativeAmountException when deducting with negative amount`() {
+        // given
+        val pointEntity = PointEntity(1L, 100L, System.currentTimeMillis() - 2)
+        val negativeAmount = -210L
+
+        // when & then
+        Assertions.assertThatThrownBy { pointEntity.deductPoint(negativeAmount) }
+            .isInstanceOf(NegativeAmountException::class.java)
+            .hasMessageContaining("amount 는 0보다 커야합니다.")
+    }
+
+    /**
+     * 0 포인트를 빼려고 하면, NegativeAmountException 을 던져야 한다.
+     */
+    @Test
+    fun `should throw NegativeAmountException when deducting with zero amount`() {
+        // given
+        val pointEntity = PointEntity(1L, 100L, System.currentTimeMillis() - 3)
+        val zeroAmount = 0L
+
+        // when & then
+        Assertions.assertThatThrownBy { pointEntity.deductPoint(zeroAmount) }
             .isInstanceOf(NegativeAmountException::class.java)
             .hasMessageContaining("amount 는 0보다 커야합니다.")
     }


### PR DESCRIPTION
## 변경사항

- PATCH  /point/{id}/use 구현
- 표현 로직 작성
    - PointController 에서 PointEntityService::use 를 호출하도록 하였습니다.
    - 반환 타입을 PointEntityDto 로 변경하였습니다.
- 응용 로직 작성
    - PointEntityService 에서 PointEntityRepository 로 부터 PointEntity 가져와, deductPoint 로 비지니스 로직을 실행합니다.
    - deductPoint 후 PointEntityService 에서 PointEntityRepository 를 통해 변경사항을 업데이트합니다.
    - 그 결과를 PointEntityDto 로 반환합니다.
- 도메인 로직 작성
    - PointEntity 의 deductPoint 에서 포인트 감소시킵니다.
    - 0 및 음수로 포인트를 감소시키려 하면, `NegativeAmountException` 을 발생시킵니다.
    - 보유 포인트보다 큰 양을 감소시키려 하면, `ExceedPointException` 을 발생시킵니다.

- EtoE Test 작성
    - PointControllerTest::`should return 200 ok with remaining point when point is sufficient`
    - PointControllerTest::`should return 400 bad request for exceed amount`

- Integration Test 작성
    - PointEntityServiceTest::`should return UserEntityDto that has deducted point`
    - PointEntityServiceTest::`should use throw ExceedPointException when trying to use more points than available`

- Unit Test 작성
    - PointEntityTest::`should decrease points and save the transaction`
    - PointEntityTest::`should throw ExceedPointException when trying with more amount than available`
    - PointEntityTest::`should throw NegativeAmountException when deducting with negative amount`
    - PointEntityTest::`should throw NegativeAmountException when deducting with zero amount`

- 리뷰 포인트
    - PointEntityService 에서 도메인 로직을 실행하고 db 에 변경사항과 transaction 을 저장하는 부분이 어떤지 리뷰 부탁드립니다.
    - UserEntity 코드 및 테스트 코드를 리뷰 부탁드립니다.